### PR TITLE
Fix: Convert.ToInt64 rounding

### DIFF
--- a/NumberTranslator.Tests/Translators/BritishEnglishNumberTranslatorTests.cs
+++ b/NumberTranslator.Tests/Translators/BritishEnglishNumberTranslatorTests.cs
@@ -51,6 +51,8 @@ public class BritishEnglishNumberTranslatorTests
 	[DataRow(-21, "negative twenty-one pounds")]
 	[DataRow(-99, "negative ninety-nine pounds")]
 	[DataRow(-100, "negative one hundred pounds")]
+	//	Test to make sure rounding when using the Convert.ToInt64 routines is handled correctly
+	[DataRow(1234.666, "one thousand, two hundred and thirty-four pounds and sixty-seven pence")]
 	public void DefaultLowerCaseTranslatorReturnsExpected(double value, string expected)
 	{
 		string actual = DefaultLowerCaseTranslator.Translate($"{value}");

--- a/NumberTranslator.Tests/Translators/EnglishNumberTranslatorTests.cs
+++ b/NumberTranslator.Tests/Translators/EnglishNumberTranslatorTests.cs
@@ -184,6 +184,8 @@ public class EnglishNumberTranslatorTests
 	[DataRow(0.000001d, "Zero")]
 	[DataRow(0.000005d, "Zero")]
 	[DataRow(0.000006d, "Zero point Zero Zero Zero Zero One")]
+	//	Test to make sure rounding when using the Convert.ToInt64 routines is handled correctly
+	[DataRow(1234.666, "One Thousand, Two Hundred and Thirty-Four point Six Six Six")]
 	public void DefaultTranslatorWithDecimalPlacesReturnsExpected(double value, string expected)
 	{
 		string actual = DefaultTranslatorWithDecimalPlaces.Translate($"{value}");
@@ -233,6 +235,8 @@ public class EnglishNumberTranslatorTests
 	[DataRow(-21, "Negative Twenty-One")]
 	[DataRow(-99, "Negative Ninety-Nine")]
 	[DataRow(-100, "Negative One Hundred")]
+	//	Test to make sure rounding when using the Convert.ToInt64 routines is handled correctly
+	[DataRow(1234.666, "One Thousand, Two Hundred and Thirty-Four and Sixty-Seven")]
 	public void DefaultTranslatorWithCurrencyAndNegativesReturnsExpected(double value, string expected)
 	{
 		string actual = DefaultTranslatorWithCurrencyAndNegatives.Translate($"{value}");

--- a/NumberTranslator/Translators/EnglishNumberTranslator.cs
+++ b/NumberTranslator/Translators/EnglishNumberTranslator.cs
@@ -154,7 +154,7 @@ public class EnglishNumberTranslator
 		//	Convert to absolute value
 		value = Math.Abs(value);
 		//	Extract integer portion of value
-		var integerPart = Convert.ToInt64(value);
+		var integerPart = Convert.ToInt64(Math.Floor(value));
 		//	Extract fractional part of value and convert to integer equivalent
 		var fractionalPart = Convert.ToInt64(Math.Pow(10, DecimalPlaces) * (value % 1));
 


### PR DESCRIPTION
Fix issues when converting values that would cause the integral part to be rounded-up when using the Convert.ToInt64 method